### PR TITLE
vSphere support in manifest files

### DIFF
--- a/lib/bosh/gen/cli.rb
+++ b/lib/bosh/gen/cli.rb
@@ -83,8 +83,9 @@ module Bosh
       method_option :addresses, :aliases => ['-a'], :type => :array, :desc => "List of IP addresses available for jobs"
       method_option :range, :aliases => ['-r'], :type => :string, :desc => "IP Netmask"
       method_option :gateway, :aliases => ['-g'], :type => :string, :desc => "IP Gateway"
-      method_option :dns, :aliases => ['-n'], :type => :array, :desc => "DNS Servers"
+      method_option :dns, :type => :array, :desc => "DNS Servers"
       method_option :workers, :aliases => ['-w'], :type => :numeric, :desc => "Number of worker VMs to spawn when compiling packages"
+      method_option :network, :aliases => ['-n'], :type => :string, :desc => "[vSphere Only] Network to bind VMs to"
       def manifest(name, release_path, uuid)
         release_path = File.expand_path(release_path)
         ip_addresses = options["addresses"] || []
@@ -95,7 +96,8 @@ module Bosh
           :range =>  options[:range] || "", 
           :gateway => options[:gateway] || "",
           :dns => options[:dns] || [],
-          :workers => options[:workers] || 10
+          :workers => options[:workers] || 10,
+          :network => options[:network] || "NETWORK_NAME"
         }
         require 'bosh/gen/generators/deployment_manifest_generator'
         Bosh::Gen::Generators::DeploymentManifestGenerator.start([name, release_path, uuid, ip_addresses, flags])

--- a/lib/bosh/gen/cli.rb
+++ b/lib/bosh/gen/cli.rb
@@ -87,7 +87,14 @@ module Bosh
       def manifest(name, release_path, uuid)
         release_path = File.expand_path(release_path)
         ip_addresses = options["addresses"] || []
-        flags = { :force => options["force"] || false, :disk => options[:disk], :cpi => options["cpi"] || "aws" }
+        flags = { 
+          :force => options["force"] || false, 
+          :disk => options[:disk], 
+          :cpi => options["cpi"] || "aws", 
+          :range =>  options[:range] || "", 
+          :gateway => options[:gateway] || "",
+          :dns => options[:dns] || []
+        }
         require 'bosh/gen/generators/deployment_manifest_generator'
         Bosh::Gen::Generators::DeploymentManifestGenerator.start([name, release_path, uuid, ip_addresses, flags])
       end

--- a/lib/bosh/gen/cli.rb
+++ b/lib/bosh/gen/cli.rb
@@ -80,10 +80,11 @@ module Bosh
       method_option :force, :type => :boolean, :desc => "Force override existing target manifest file"
       method_option :addresses, :aliases => ['-a'], :type => :array, :desc => "List of IP addresses available for jobs"
       method_option :disk, :aliases => ['-d'], :type => :string, :desc => "Attach persistent disks to VMs of specific size, e.g. 8196"
+      method_option :cpi, :aliases => ['-c'], :type => :string, :desc => "Specify the CPI fields to be generated, e.g. \"aws\" or \"vsphere\""
       def manifest(name, release_path, uuid)
         release_path = File.expand_path(release_path)
         ip_addresses = options["addresses"] || []
-        flags = { :force => options["force"] || false, :disk => options[:disk] }
+        flags = { :force => options["force"] || false, :disk => options[:disk], :cpi => options["cpi"] || "aws" }
         require 'bosh/gen/generators/deployment_manifest_generator'
         Bosh::Gen::Generators::DeploymentManifestGenerator.start([name, release_path, uuid, ip_addresses, flags])
       end

--- a/lib/bosh/gen/cli.rb
+++ b/lib/bosh/gen/cli.rb
@@ -84,6 +84,7 @@ module Bosh
       method_option :range, :aliases => ['-r'], :type => :string, :desc => "IP Netmask"
       method_option :gateway, :aliases => ['-g'], :type => :string, :desc => "IP Gateway"
       method_option :dns, :aliases => ['-n'], :type => :array, :desc => "DNS Servers"
+      method_option :workers, :aliases => ['-w'], :type => :numeric, :desc => "Number of worker VMs to spawn when compiling packages"
       def manifest(name, release_path, uuid)
         release_path = File.expand_path(release_path)
         ip_addresses = options["addresses"] || []
@@ -93,7 +94,8 @@ module Bosh
           :cpi => options["cpi"] || "aws", 
           :range =>  options[:range] || "", 
           :gateway => options[:gateway] || "",
-          :dns => options[:dns] || []
+          :dns => options[:dns] || [],
+          :workers => options[:workers] || 10
         }
         require 'bosh/gen/generators/deployment_manifest_generator'
         Bosh::Gen::Generators::DeploymentManifestGenerator.start([name, release_path, uuid, ip_addresses, flags])

--- a/lib/bosh/gen/cli.rb
+++ b/lib/bosh/gen/cli.rb
@@ -78,9 +78,12 @@ module Bosh
 
       desc "manifest NAME PATH UUID", "Creates a deployment manifest based on the release located at PATH"
       method_option :force, :type => :boolean, :desc => "Force override existing target manifest file"
-      method_option :addresses, :aliases => ['-a'], :type => :array, :desc => "List of IP addresses available for jobs"
-      method_option :disk, :aliases => ['-d'], :type => :string, :desc => "Attach persistent disks to VMs of specific size, e.g. 8196"
       method_option :cpi, :aliases => ['-c'], :type => :string, :desc => "Specify the CPI fields to be generated, e.g. \"aws\" or \"vsphere\""
+      method_option :disk, :aliases => ['-d'], :type => :string, :desc => "Attach persistent disks to VMs of specific size, e.g. 8196"
+      method_option :addresses, :aliases => ['-a'], :type => :array, :desc => "List of IP addresses available for jobs"
+      method_option :range, :aliases => ['-r'], :type => :string, :desc => "IP Netmask"
+      method_option :gateway, :aliases => ['-g'], :type => :string, :desc => "IP Gateway"
+      method_option :dns, :aliases => ['-n'], :type => :array, :desc => "DNS Servers"
       def manifest(name, release_path, uuid)
         release_path = File.expand_path(release_path)
         ip_addresses = options["addresses"] || []

--- a/lib/bosh/gen/generators/deployment_manifest_generator.rb
+++ b/lib/bosh/gen/generators/deployment_manifest_generator.rb
@@ -33,17 +33,17 @@ module Bosh::Gen
           cloud_properties["static"]["range"] = flags[:range].dup || ""
           cloud_properties["static"]["gateway"] = flags[:gateway].dup || ""
           cloud_properties["static"]["dns"] = flags[:dns].dup || []
-          options = {:cpi => "vsphere", :stemcell_version => "0.5.2"}
+          options = {:cpi => "vsphere", :stemcell_version => "0.5.2", :workers => flags[:workers]}
         when "aws"
           security_groups = ["default"]
           cloud_properties = { "compilation" => { "instance_type" => "m1.small", "availability_zone" => "us-east-1e" } }
           cloud_properties["compilation"]["persistent_disk"] = flags[:disk] if flags[:disk]
           cloud_properties["static"] = { "addresses" => ip_addresses.dup }
           cloud_properties["network"] = { "security_groups" => security_groups.dup } if security_groups.any?
-          options = {:cpi => "aws", :stemcell_version => "0.5.1"}
+          options = {:cpi => "aws", :stemcell_version => "0.5.1", :workers => flags[:workers]}
         else
           raise Thor::Error.new("Unknown CPI: #{flags[:cpi]}")
-        end
+        end      
         manifest = Bosh::Gen::Models::DeploymentManifest.new(name, director_uuid, release_properties, cloud_properties, options)
         manifest.jobs = job_manifests
         create_file manifest_file_name, manifest.to_yaml, :force => flags[:force]

--- a/lib/bosh/gen/generators/deployment_manifest_generator.rb
+++ b/lib/bosh/gen/generators/deployment_manifest_generator.rb
@@ -27,14 +27,15 @@ module Bosh::Gen
       def create_deployment_manifest
         case flags[:cpi].downcase
         when "vsphere"
-          security_groups = ["default"]
           cloud_properties = { "compilation" => { "ram" => 2048, "disk" => 8192, "cpu" => 2 } }
           cloud_properties["network"] = { "name" => "VLAN_NAME" }
+          cloud_properties["compilation"]["static"] = ip_addresses.dup if ip_addresses.any?
         when "aws"
+          security_groups = ["default"]
           cloud_properties = { "compilation" => { "instance_type" => "m1.small", "availability_zone" => "us-east-1e" } }
           cloud_properties["compilation"]["persistent_disk"] = flags[:disk] if flags[:disk]
-          cloud_properties["compilation"]["static_ips"] = ip_addresses if ip_addresses.any?
-          cloud_properties["network"] = { "security_groups" => @security_groups.dup }
+          cloud_properties["compilation"]["static_ips"] = ip_addresses.dup if ip_addresses.any?
+          cloud_properties["network"] = { "security_groups" => security_groups.dup } if security_groups.any?
         else
           raise Thor::Error.new("Unknown CPI: #{flags[:cpi]}")
         end

--- a/lib/bosh/gen/generators/deployment_manifest_generator.rb
+++ b/lib/bosh/gen/generators/deployment_manifest_generator.rb
@@ -29,13 +29,13 @@ module Bosh::Gen
         when "vsphere"
           cloud_properties = { "compilation" => { "ram" => 2048, "disk" => 8192, "cpu" => 2 } }
           cloud_properties["network"] = { "name" => "VLAN_NAME" }
-          cloud_properties["network"]["static"] = ip_addresses.dup if ip_addresses.any?
+          cloud_properties["static"] = ip_addresses.dup if ip_addresses.any?
           options = {"cpi" => "vsphere", "stemcell_version" => "0.5.2"}
         when "aws"
           security_groups = ["default"]
           cloud_properties = { "compilation" => { "instance_type" => "m1.small", "availability_zone" => "us-east-1e" } }
           cloud_properties["compilation"]["persistent_disk"] = flags[:disk] if flags[:disk]
-          cloud_properties["compilation"]["static_ips"] = ip_addresses.dup if ip_addresses.any?
+          cloud_properties["static"] = ip_addresses.dup if ip_addresses.any?
           cloud_properties["network"] = { "security_groups" => security_groups.dup } if security_groups.any?
           options = {"cpi" => "aws", "stemcell_version" => "0.5.1"}
         else

--- a/lib/bosh/gen/generators/deployment_manifest_generator.rb
+++ b/lib/bosh/gen/generators/deployment_manifest_generator.rb
@@ -29,17 +29,19 @@ module Bosh::Gen
         when "vsphere"
           cloud_properties = { "compilation" => { "ram" => 2048, "disk" => 8192, "cpu" => 2 } }
           cloud_properties["network"] = { "name" => "VLAN_NAME" }
-          cloud_properties["compilation"]["static"] = ip_addresses.dup if ip_addresses.any?
+          cloud_properties["network"]["static"] = ip_addresses.dup if ip_addresses.any?
+          options = {"cpi" => "vsphere", "stemcell_version" => "0.5.2"}
         when "aws"
           security_groups = ["default"]
           cloud_properties = { "compilation" => { "instance_type" => "m1.small", "availability_zone" => "us-east-1e" } }
           cloud_properties["compilation"]["persistent_disk"] = flags[:disk] if flags[:disk]
           cloud_properties["compilation"]["static_ips"] = ip_addresses.dup if ip_addresses.any?
           cloud_properties["network"] = { "security_groups" => security_groups.dup } if security_groups.any?
+          options = {"cpi" => "aws", "stemcell_version" => "0.5.1"}
         else
           raise Thor::Error.new("Unknown CPI: #{flags[:cpi]}")
         end
-        manifest = Bosh::Gen::Models::DeploymentManifest.new(name, director_uuid, release_properties, cloud_properties)
+        manifest = Bosh::Gen::Models::DeploymentManifest.new(name, director_uuid, release_properties, cloud_properties, options)
         manifest.jobs = job_manifests
         create_file manifest_file_name, manifest.to_yaml, :force => flags[:force]
       end

--- a/lib/bosh/gen/generators/deployment_manifest_generator.rb
+++ b/lib/bosh/gen/generators/deployment_manifest_generator.rb
@@ -29,15 +29,18 @@ module Bosh::Gen
         when "vsphere"
           cloud_properties = { "compilation" => { "ram" => 2048, "disk" => 8192, "cpu" => 2 } }
           cloud_properties["network"] = { "name" => "VLAN_NAME" }
-          cloud_properties["static"] = ip_addresses.dup if ip_addresses.any?
-          options = {"cpi" => "vsphere", "stemcell_version" => "0.5.2"}
+          cloud_properties["static"] = { "addresses" => ip_addresses.dup }
+          cloud_properties["static"]["range"] = flags[:range].dup || ""
+          cloud_properties["static"]["gateway"] = flags[:gateway].dup || ""
+          cloud_properties["static"]["dns"] = flags[:dns].dup || []
+          options = {:cpi => "vsphere", :stemcell_version => "0.5.2"}
         when "aws"
           security_groups = ["default"]
           cloud_properties = { "compilation" => { "instance_type" => "m1.small", "availability_zone" => "us-east-1e" } }
           cloud_properties["compilation"]["persistent_disk"] = flags[:disk] if flags[:disk]
           cloud_properties["static"] = ip_addresses.dup if ip_addresses.any?
           cloud_properties["network"] = { "security_groups" => security_groups.dup } if security_groups.any?
-          options = {"cpi" => "aws", "stemcell_version" => "0.5.1"}
+          options = {:cpi => "aws", :stemcell_version => "0.5.1"}
         else
           raise Thor::Error.new("Unknown CPI: #{flags[:cpi]}")
         end

--- a/lib/bosh/gen/generators/deployment_manifest_generator.rb
+++ b/lib/bosh/gen/generators/deployment_manifest_generator.rb
@@ -38,7 +38,7 @@ module Bosh::Gen
           security_groups = ["default"]
           cloud_properties = { "compilation" => { "instance_type" => "m1.small", "availability_zone" => "us-east-1e" } }
           cloud_properties["compilation"]["persistent_disk"] = flags[:disk] if flags[:disk]
-          cloud_properties["static"] = ip_addresses.dup if ip_addresses.any?
+          cloud_properties["static"] = { "addresses" => ip_addresses.dup }
           cloud_properties["network"] = { "security_groups" => security_groups.dup } if security_groups.any?
           options = {:cpi => "aws", :stemcell_version => "0.5.1"}
         else

--- a/lib/bosh/gen/generators/deployment_manifest_generator.rb
+++ b/lib/bosh/gen/generators/deployment_manifest_generator.rb
@@ -28,12 +28,12 @@ module Bosh::Gen
         case flags[:cpi].downcase
         when "vsphere"
           cloud_properties = { "compilation" => { "ram" => 2048, "disk" => 8192, "cpu" => 2 } }
-          cloud_properties["network"] = { "name" => "VLAN_NAME" }
+          cloud_properties["network"] = { "name" => flags[:network].dup }
           cloud_properties["static"] = { "addresses" => ip_addresses.dup }
           cloud_properties["static"]["range"] = flags[:range].dup || ""
           cloud_properties["static"]["gateway"] = flags[:gateway].dup || ""
           cloud_properties["static"]["dns"] = flags[:dns].dup || []
-          options = {:cpi => "vsphere", :stemcell_version => "0.5.2", :workers => flags[:workers]}
+          options = {:cpi => "vsphere", :stemcell_version => "0.5.2", :workers => flags[:workers], :network => flags[:network]}
         when "aws"
           security_groups = ["default"]
           cloud_properties = { "compilation" => { "instance_type" => "m1.small", "availability_zone" => "us-east-1e" } }

--- a/lib/bosh/gen/models/deployment_manifest.rb
+++ b/lib/bosh/gen/models/deployment_manifest.rb
@@ -18,7 +18,7 @@ module Bosh::Gen::Models
       manifest["compilation"] = {
         "workers" => 10,
         "network" => "default",
-        "cloud_properties" => cloud_properties["compilation"].dup
+        "cloud_properties" => YAML.load(YAML.dump(cloud_properties["compilation"]))
       }
       manifest["update"] = {
         "canaries" => 1,
@@ -31,12 +31,12 @@ module Bosh::Gen::Models
         {
           "name" => "default",
           "type" => "dynamic",
-          "cloud_properties" => YAML.load(YAML.dump(cloud_properties["network"])) # Deep copy issue, is there a better way to do this?
+          "cloud_properties" => YAML.load(YAML.dump(cloud_properties["network"]))
         },
         {
           "name" => "vip_network",
           "type" => "vip",
-          "cloud_properties" => YAML.load(YAML.dump(cloud_properties["network"])) # Deep copy issue, is there a better way to do this?
+          "cloud_properties" => YAML.load(YAML.dump(cloud_properties["network"]))
         }
       ]
       manifest["resource_pools"] = [
@@ -45,7 +45,7 @@ module Bosh::Gen::Models
           "network" => "default",
           "size" => 0,
           "stemcell" => @stemcell,
-          "cloud_properties" => cloud_properties["compilation"].dup
+          "cloud_properties" => YAML.load(YAML.dump(cloud_properties["compilation"]))
         }
       ]
       manifest["resource_pools"].first["persistent_disk"] = @persistent_disk if @persistent_disk > 0

--- a/lib/bosh/gen/models/deployment_manifest.rb
+++ b/lib/bosh/gen/models/deployment_manifest.rb
@@ -7,7 +7,6 @@ module Bosh::Gen::Models
     def initialize(name, director_uuid, release_properties, cloud_properties)
       @manifest = {}
       @cloud_properties = cloud_properties
-      @security_groups = ["default"]
       @stemcell_version = "0.5.1"
       @stemcell = { "name" => "bosh-stemcell", "version" => @stemcell_version }
       @persistent_disk = cloud_properties.delete("persistent_disk").to_i
@@ -19,7 +18,7 @@ module Bosh::Gen::Models
       manifest["compilation"] = {
         "workers" => 10,
         "network" => "default",
-        "cloud_properties" => cloud_properties.dup
+        "cloud_properties" => cloud_properties["compilation"].dup
       }
       manifest["update"] = {
         "canaries" => 1,
@@ -32,12 +31,12 @@ module Bosh::Gen::Models
         {
           "name" => "default",
           "type" => "dynamic",
-          "cloud_properties" => { "security_groups" => @security_groups.dup }
+          "cloud_properties" => YAML.load(YAML.dump(cloud_properties["network"])) # Deep copy issue, is there a better way to do this?
         },
         {
           "name" => "vip_network",
           "type" => "vip",
-          "cloud_properties" => { "security_groups" => @security_groups.dup }
+          "cloud_properties" => YAML.load(YAML.dump(cloud_properties["network"])) # Deep copy issue, is there a better way to do this?
         }
       ]
       manifest["resource_pools"] = [
@@ -46,7 +45,7 @@ module Bosh::Gen::Models
           "network" => "default",
           "size" => 0,
           "stemcell" => @stemcell,
-          "cloud_properties" => cloud_properties.dup
+          "cloud_properties" => cloud_properties["compilation"].dup
         }
       ]
       manifest["resource_pools"].first["persistent_disk"] = @persistent_disk if @persistent_disk > 0

--- a/lib/bosh/gen/models/deployment_manifest.rb
+++ b/lib/bosh/gen/models/deployment_manifest.rb
@@ -11,8 +11,8 @@ module Bosh::Gen::Models
       @cloud_properties = cloud_properties
       @stemcell = { "name" => "bosh-stemcell", "version" => options["stemcell_version"] }
       @persistent_disk = cloud_properties.delete("persistent_disk").to_i
-      @static_ips = cloud_properties.delete("static_ips") || []
-      
+      @static_ips = cloud_properties["static"] || []
+
       manifest["name"] = name
       manifest["director_uuid"] = director_uuid
       manifest["release"] = release_properties.dup

--- a/lib/bosh/gen/models/deployment_manifest.rb
+++ b/lib/bosh/gen/models/deployment_manifest.rb
@@ -4,11 +4,12 @@ module Bosh::Gen::Models
   class DeploymentManifest
     attr_reader :manifest
     
-    def initialize(name, director_uuid, release_properties, cloud_properties)
+    default_options = {"cpi" => "aws", "stemcell_version" => "0.5.1"}
+    
+    def initialize(name, director_uuid, release_properties, cloud_properties, options=default_options)
       @manifest = {}
       @cloud_properties = cloud_properties
-      @stemcell_version = "0.5.1"
-      @stemcell = { "name" => "bosh-stemcell", "version" => @stemcell_version }
+      @stemcell = { "name" => "bosh-stemcell", "version" => options["stemcell_version"] }
       @persistent_disk = cloud_properties.delete("persistent_disk").to_i
       @static_ips = cloud_properties.delete("static_ips") || []
       
@@ -27,6 +28,7 @@ module Bosh::Gen::Models
         "max_in_flight" => 4,
         "max_errors" => 1
       }
+      
       manifest["networks"] = [
         {
           "name" => "default",

--- a/lib/bosh/gen/models/deployment_manifest.rb
+++ b/lib/bosh/gen/models/deployment_manifest.rb
@@ -4,7 +4,7 @@ module Bosh::Gen::Models
   class DeploymentManifest
     attr_reader :manifest
     
-    default_options = {:cpi => "aws", :stemcell_version => "0.5.1"}
+    default_options = {:cpi => "aws", :stemcell_version => "0.5.1", :workers => 10 }
     
     def initialize(name, director_uuid, release_properties, cloud_properties, options=default_options)
       @manifest = {}
@@ -18,7 +18,7 @@ module Bosh::Gen::Models
       manifest["director_uuid"] = director_uuid
       manifest["release"] = release_properties.dup
       manifest["compilation"] = {
-        "workers" => 10,
+        "workers" => options[:workers],
         "network" => "default",
         "cloud_properties" => YAML.load(YAML.dump(cloud_properties["compilation"]))
       }


### PR DESCRIPTION
This branch adds support for generating manifest files to deploy a release to vSphere. The following flags were also added to `bosh-gen manifest`

`
-c, [--cpi=CPI]                  # Specify the CPI fields to be generated, e.g. "aws" or "vsphere"  
-r, [--range=RANGE]              # IP Netmask
-g, [--gateway=GATEWAY]          # IP Gateway
    [--dns=one two three]        # DNS Servers
-w, [--workers=N]                # Number of worker VMs to spawn when compiling packages
-n, [--network=NETWORK]          # [vSphere Only] Network to bind VMs to
`

While not the cleanest code, it works, and I did a few tests to make sure I didn't break anything AWS related, however it's not a bad idea to do so, since I didn't have a chance to do so. I did generate a couple AWS manifests (w/ and w/o static IPs) and just did a diff against them, and this branch still seems to generate AWS manifests as it did before. This has been tested deploying to vSphere 5 with only ESXi 5 hosts, however I believe any limitations would be seen in the CPI before these manifests.

There's a couple things to keep in mind...

1. It is expected that vSphere manifests will only have static IP assignment. This is simply because I havn't found a good example for dynamic IP assignment in vSphere manifests. Once I find/am given one, I'll submit another pull request.
2. For vSphere deployments, the -c, -r, -g, --dns and -n flags are REQUIRED. This information is needed for basic static IP assignment, as well as the -n flag to know which network to bind a VM to in vSphere
3. AWS is the default CPI (I wanted to allow previous examples to still be valid, plus AWS was here first :) ), so when generating vSphere manifests, the "-c vsphere" is required.

An example command used to generate a manifest for vSphere is as follows...

bosh-gen manifest redis-dev redis-on-demand xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxx -c vsphere -a 192.168.0.100 -r 192.168.0.0/24 -g 192.168.0.1 --dns 192.168.0.1 192.168.0.2 -n "Development Network" -w 1