### PR TITLE
Add a new blobstore provider: OpenStack Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Or install it yourself as:
 ```
 $ bosh-gen new my-new-project --s3
 $ bosh-gen new my-new-project --atmos
+$ bosh-gen new my-new-project --swift
 $ bosh-gen new my-new-project # local blobstore with a warning
 
 $ cd my-new-project
 ```
 
-**NEXT:** Edit `config/final.yml` with your S3 or ATMOS credentials
+**NEXT:** Edit `config/final.yml` with your S3, ATMOS or Swift credentials
 
 ```
 $ bosh create release

--- a/lib/bosh/gen/cli.rb
+++ b/lib/bosh/gen/cli.rb
@@ -17,8 +17,11 @@ module Bosh
         :desc => "Use AWS S3 bucket for blobstore"
       method_option :atmos, :type => :boolean, 
         :desc => "Use EMC ATMOS for blobstore"
+      method_option :swift, :type => :boolean,
+        :desc => "Use OpenStack Swift for blobstore"
       def new(path)
-        flags = { :aws => options["s3"], :atmos => options["atmos"] }
+        flags = { :aws => options["s3"], :atmos => options["atmos"],
+                  :swift => options["swift"]}
         
         require 'bosh/gen/generators/new_release_generator'
         Bosh::Gen::Generators::NewReleaseGenerator.start([path, flags])

--- a/lib/bosh/gen/generators/new_release_generator.rb
+++ b/lib/bosh/gen/generators/new_release_generator.rb
@@ -69,6 +69,22 @@ module Bosh::Gen
               }
             }
           }
+        when :swift
+          config_private = {
+            "blobstore" => {
+              "swift" => {
+                "rackspace" => {
+                  "rackspace_username" => "USERNAME",
+                  "rackspace_api_key" => "API_KEY"
+                },
+                "hp" => {
+                  "hp_account_id" => "ACCESS_KEY_ID",
+                  "hp_secret_key" => "SECRET_KEY",
+                  "hp_tenant_id" => "TENANT_ID"
+                },
+              }
+            }
+          }
         end
         create_file "config/private.yml", YAML.dump(config_private)
 
@@ -98,6 +114,15 @@ module Bosh::Gen
                 "tag" => "BOSH",
                 "url" => "https://blob.cfblob.com",
                 "uid" => "ATMOS_UID"
+              }
+            }
+          }
+        when :swift
+          config_final = { "blobstore" => {
+              "provider" => "swift",
+              "options" => {
+                "container_name" => "BOSH",
+                "swift_provider" => "SWIFT_PROVIDER"
               }
             }
           }
@@ -142,6 +167,7 @@ module Bosh::Gen
       def blobstore_type
         return :s3 if s3?
         return :atmos if atmos?
+        return :swift if swift?
         return :local
       end
       
@@ -151,6 +177,10 @@ module Bosh::Gen
       
       def atmos?
         flags[:atmos]
+      end
+
+      def swift?
+        flags[:swift]
       end
 
       # Run a command in git.


### PR DESCRIPTION
A new blobstore provider is now supported in BOSH (cloudfoundry/bosh@7b007d75928410e4f7f7387d23de40cdc93ddf6d), so I added a new option (--swift) at the "new" command to generate private.yml and final.yml with OpenStack Swift provider options.
