### PR TITLE
Gemspec Dependency Versioning removal

### DIFF
--- a/bosh-gen.gemspec
+++ b/bosh-gen.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.version       = Bosh::Gen::VERSION
   
   gem.add_dependency "thor"
-  gem.add_dependency "bosh_cli", "~> 1.0"
-  gem.add_dependency "bosh_common", "~> 0.5"
+  gem.add_dependency "bosh_cli"
+  gem.add_dependency "bosh_common"
   
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest", "~> 2.12"


### PR DESCRIPTION
Hey there,

i created a gem release with the included rake task using the master branch. After installing the gem, i tried to test it, but it failed when executing "bosh-gen new <my_project_name": It detected problems with the versions of bosh_common and bosh_cli.

So i removed the versioning information from the gemspec, rebuild the gem and installed it. now i was able to execute the gem commands as needed.

Regards,
Julian W
## 

anynines.com
