### PR TITLE
[bosh-gen package apt] Upgrade Vagrant Ubuntu from Precise to Trusty

### DIFF
--- a/lib/bosh/gen/generators/package_apt_generator/templates/Vagrantfile
+++ b/lib/bosh/gen/generators/package_apt_generator/templates/Vagrantfile
@@ -3,8 +3,7 @@
 Vagrant.configure('2') do |config|
 
   config.vm.hostname='boshrelease-builder'
-  config.vm.box = "lucid64"
-  config.vm.box_url = "http://files.vagrantup.com/lucid64.box"
+  config.vm.box = "ubuntu/trusty64"
 
   # Need NFS enabled, and hence a private network for virtualbox
   # as discussed in this project's patch


### PR DESCRIPTION
[bosh-gen package apt] Upgrade Vagrant Ubuntu from Precise to Trusty as ...current Ubuntu stemcells are based on Trusty