### PR TITLE
update warden network to cidr

### DIFF
--- a/lib/bosh/gen/generators/new_release_generator/templates/templates/infrastructure-warden.yml.tt
+++ b/lib/bosh/gen/generators/new_release_generator/templates/templates/infrastructure-warden.yml.tt
@@ -27,70 +27,10 @@ resource_pools:
 
 networks:
 - name: <%= project_name_underscored %>1
-  # Assumes up to 5 VMs, including 1 static and 4 dynamic.
-  # Plus 5 (double the size) unused IPs, due to BOSH bug/quirk.
+  type: manual
   subnets:
-  - cloud_properties:
-      name: random
-    range: 10.244.2.0/30
-    reserved:
-    - 10.244.2.1
+  - range: 10.244.2.0/24
+    name: <%= project_name_underscored %>1
+    gateway: 10.244.2.1
     static:
-    - 10.244.2.2
-
-  - cloud_properties:
-      name: random
-    range: 10.244.2.4/30
-    reserved:
-    - 10.244.2.5
-    static: []
-  - cloud_properties:
-      name: random
-    range: 10.244.2.8/30
-    reserved:
-    - 10.244.2.9
-    static: []
-  - cloud_properties:
-      name: random
-    range: 10.244.2.12/30
-    reserved:
-    - 10.244.2.13
-    static: []
-  - cloud_properties:
-      name: random
-    range: 10.244.2.16/30
-    reserved:
-    - 10.244.2.17
-    static: []
-
-  # Bonus double-sized network required due to BOSH oddity
-  - cloud_properties:
-      name: random
-    range: 10.244.2.20/30
-    reserved:
-    - 10.244.2.21
-    static: []
-  - cloud_properties:
-      name: random
-    range: 10.244.2.24/30
-    reserved:
-    - 10.244.2.25
-    static: []
-  - cloud_properties:
-      name: random
-    range: 10.244.2.28/30
-    reserved:
-    - 10.244.2.29
-    static: []
-  - cloud_properties:
-      name: random
-    range: 10.244.2.32/30
-    reserved:
-    - 10.244.2.33
-    static: []
-  - cloud_properties:
-      name: random
-    range: 10.244.2.36/30
-    reserved:
-    - 10.244.2.37
-    static: []
+      - 10.244.2.2-10.244.2.60


### PR DESCRIPTION
Assuming target is new garden-based bosh-lite now