### PR TITLE
Fixed stemcell URLs from 'bosh public stemcells' to bosh.io

### DIFF
--- a/lib/bosh/gen/generators/new_release_generator/templates/templates/make_manifest.tt
+++ b/lib/bosh/gen/generators/new_release_generator/templates/templates/make_manifest.tt
@@ -7,11 +7,24 @@ STEMCELL_OS=${STEMCELL_OS:-ubuntu}
 
 infrastructure=$1
 
-if [ "$infrastructure" != "aws-ec2" ] && \
-    [ "$infrastructure" != "warden" ] ; then
-  echo "usage: ./make_manifest <aws-ec2|warden>"
+fail() {
+	echo >&2 $*
+}
+
+if [[ "$infrastructure" != "aws-ec2" && "$infrastructure" != "warden" ]] ; then
+  fail "usage: ./make_manifest <aws-ec2|warden>"
   exit 1
 fi
+
+case "${infrastructure}/${STEMCELL_OS}" in
+  (warden/*)       STEMCELL_URL="https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent" ;;
+  (aws-ec2/ubuntu) STEMCELL_URL="https://bosh.io/d/stemcells/bosh-aws-xen-ubuntu-trusty-go_agent" ;;
+  (aws-ec2/centos) STEMCELL_URL="https://bosh.io/d/stemcells/bosh-aws-xen-centos-7-go_agent" ;;
+  (*)
+    fail "Invalid infrastructure or OS specified."
+    exit 1
+    ;;
+esac
 
 shift
 
@@ -21,18 +34,14 @@ DIRECTOR_CPI=$(echo "$BOSH_STATUS" | grep CPI | awk '{print $2}' | sed -e 's/_cp
 DIRECTOR_NAME=$(echo "$BOSH_STATUS" | grep Name | awk '{print $2}')
 NAME=$template_prefix-$infrastructure
 
-if [[ $DIRECTOR_NAME = "warden" ]]; then
-  if [[ $infrastructure != "warden" ]]; then
-    echo "Not targeting bosh-lite with warden CPI. Please use 'bosh target' before running this script."
-    exit 1
-  fi
+if [[ $DIRECTOR_NAME = "warden" && ${infrastructure} != "warden" ]]; then
+  fail "Not targeting bosh-lite with warden CPI. Please make sure you have run 'bosh target' and are targeting a BOSH lite before running this script."
+  exit 1
 fi
 
-if [[ $infrastructure = "aws-ec2" ]]; then
-  if [[ $DIRECTOR_CPI != "aws" ]]; then
-    echo "Not targeting an AWS BOSH. Please use 'bosh target' before running this script."
-    exit 1
-  fi
+if [[ $infrastructure = "aws-ec2" && ${DIRECTOR_CPI} != "aws" ]]; then
+  fail "Not targeting an AWS BOSH. Please make sure you have run 'bosh target' and are targeting an AWS BOSH before running this script."
+  exit 1
 fi
 
 function latest_uploaded_stemcell {
@@ -40,7 +49,7 @@ function latest_uploaded_stemcell {
 }
 
 STEMCELL=${STEMCELL:-$(latest_uploaded_stemcell)}
-if [[ "${STEMCELL}X" == "X" ]]; then
+if [[ -z ${STEMCELL} ]]; then
   echo
   echo "Uploading latest $DIRECTOR_CPI/$STEMCELL_OS stemcell..."
   STEMCELL_URL=$(bosh public stemcells --full | grep $DIRECTOR_CPI | grep $STEMCELL_OS | sort -nr | head -n1 | awk '{ print $4 }')


### PR DESCRIPTION
`make_manifest` was using `bosh public stemcells` to get BOSH stemcells rather than bosh.io URLs, updated to use bosh.io URLs. 