### PR TITLE
Fix rspec tests / Travis script / Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "rspec/core/rake_task"
 
 desc "Run Tests"
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = "spec/unit/**/*_spec.rb"
+  t.pattern = "spec/{generators,models}/**/*_spec.rb"
   t.rspec_opts = %w(--format progress --color)
 end
 

--- a/spec/generators/job_generator_spec.rb
+++ b/spec/generators/job_generator_spec.rb
@@ -18,7 +18,7 @@ describe Bosh::Gen::Generators::JobGenerator do
       generate_job("mywebapp")
       expect(File.exist?("jobs/mywebapp/monit")).to eq(true)
       expect(File.exist?("jobs/mywebapp/spec")).to eq(true)
-      job_template_exists "mywebapp", "bin/mywebapp_ctl",       "bin/mywebapp_ctl"
+      job_template_exists "mywebapp", "bin/ctl",                "bin/ctl"
       job_template_exists "mywebapp", "bin/monit_debugger",     "bin/monit_debugger"
       job_template_exists "mywebapp", "data/properties.sh.erb", "data/properties.sh"
       job_template_exists "mywebapp", "helpers/ctl_setup.sh",   "helpers/ctl_setup.sh"


### PR DESCRIPTION
88c7c74fd3 changed the path of bin/$JOBNAME_ctl to just bin/ctl.  At
that point, `rspec` started failing.  At the same time, Travis was
running `bundle exec rake spec`, which was looking at the wrong file
pattern.