### PR TITLE
Fix instructions for release upload in README.md

### DIFF
--- a/lib/bosh/gen/generators/new_release_generator/templates/README.md.tt
+++ b/lib/bosh/gen/generators/new_release_generator/templates/README.md.tt
@@ -8,7 +8,7 @@ To use this bosh release, first upload it to your bosh:
 bosh target BOSH_HOST
 git clone https://github.com/cloudfoundry-community/<%= repository_name %>.git
 cd <%= repository_name %>
-bosh upload release releases/<%= project_name %>-1.yml
+bosh upload release releases/<%= project_name %>/<%= project_name %>-1.yml
 ```
 
 For [bosh-lite](https://github.com/cloudfoundry/bosh-lite), you can quickly create a deployment manifest & deploy a cluster:


### PR DESCRIPTION
At some point, BOSH changed form using releases/<name>-<v>.yml to using
releases/<name>/<name>-<v>.yml.  Older releases like consul-boshrelease
seem to have introduced a symlink for this, but newer releases like
shell-boshrelease and vault-boshrelease (all in cloudfoundry-community
org on Github) do not.