### PR TITLE
Drop EXITSTATUS handling in errand `bin/run` template

### DIFF
--- a/lib/bosh/gen/generators/errand_generator/templates/jobs/%job_name%/templates/bin/run.tt
+++ b/lib/bosh/gen/generators/errand_generator/templates/jobs/%job_name%/templates/bin/run.tt
@@ -3,10 +3,10 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-# Setup env vars and folders for the webapp_ctl script
+# Setup env vars and folders for the errand script
 source /var/vcap/jobs/<%= job_name %>/helpers/ctl_setup.sh '<%= job_name %>'
 
-EXITSTATUS=0
+############################################################################
 
-echo "Errand <%= job_name %> is complete; exit status $EXITSTATUS"
-exit $EXITSTATUS
+# put your errand steps here...
+


### PR DESCRIPTION
BOSH CLI does a great job of splitting output and reporting on errand
exit status (with coloring even!), so we don't need to do it in the
generated templates.

Here's an example run under the proposed changes (with a failing `ls` call):

```
[stdout]
$PATH /usr/sbin:/usr/bin:/sbin:/bin

[stderr]
ls: cannot access /path/to/nowhere: No such file or directory

Errand `test' completed with error (exit code 2)
```

and here's a successful run:

```
Started         2016-03-24 14:23:39 UTC
Finished        2016-03-24 14:24:04 UTC
Duration        00:00:25

[stdout]
$PATH /usr/sbin:/usr/bin:/sbin:/bin
total 72
drwxr-xr-x   2 root root 4096 Dec  1 00:27 bin
drwxr-xr-x   3 root root 4096 Dec  1 00:33 boot
drwxr-xr-x   5 root root 4096 Mar 24 14:23 dev
drwxr-xr-x  89 root root 4096 Mar 24 14:23 etc
drwxr-xr-x   3 root root 4096 Dec  1 00:32 home
lrwxrwxrwx   1 root root   33 Dec  1 00:31 initrd.img -> boot/initrd.img-3.19.0-33-generic
drwxr-xr-x  17 root root 4096 Dec  1 00:29 lib
drwxr-xr-x   2 root root 4096 Dec  1 00:25 lib64
drwxr-xr-x   2 root root 4096 Dec  1 00:22 media
drwxr-xr-x   2 root root 4096 Apr 10  2014 mnt
drwxr-xr-x   2 root root 4096 Dec  1 00:22 opt
dr-xr-xr-x 335 root root    0 Mar 24 14:23 proc
drwx------   3 root root 4096 Mar 24 14:23 root
drwxr-xr-x  10 root root 4096 Mar 24 14:23 run
drwxr-xr-x   2 root root 4096 Dec  4 07:05 sbin
drwxr-xr-x   2 root root 4096 Dec  1 00:22 srv
dr-xr-xr-x  13 root root    0 Mar 24 14:23 sys
drwxrwx---   3 root vcap 4096 Mar 24 14:23 tmp
drwxr-xr-x  11 root root 4096 Dec  4 06:47 usr
drwxr-xr-x  15 root root 4096 Mar 24 14:23 var
lrwxrwxrwx   1 root root   30 Dec  1 00:31 vmlinuz -> boot/vmlinuz-3.19.0-33-generic
drwxr-xr-x   2 root root 4096 Mar 24 14:23 warden-cpi-dev

[stderr]

Errand `test' completed successfully (exit code 0)
```