### PR TITLE
Use STEMCELL_URL and avoid `bosh public stemcells`

### DIFF
--- a/lib/bosh/gen/generators/new_release_generator/templates/templates/make_manifest.tt
+++ b/lib/bosh/gen/generators/new_release_generator/templates/templates/make_manifest.tt
@@ -52,7 +52,7 @@ STEMCELL=${STEMCELL:-$(latest_uploaded_stemcell)}
 if [[ -z ${STEMCELL} ]]; then
   echo
   echo "Uploading latest $DIRECTOR_CPI/$STEMCELL_OS stemcell..."
-  STEMCELL_URL=$(bosh public stemcells --full | grep $DIRECTOR_CPI | grep $STEMCELL_OS | sort -nr | head -n1 | awk '{ print $4 }')
+  echo " (from ${STEMCELL_URL})"
   bosh upload stemcell $STEMCELL_URL
 fi
 STEMCELL=${STEMCELL:-$(latest_uploaded_stemcell)}


### PR DESCRIPTION
If you start with a brand new BOSH-lite environment (no stemcells),
previous versions of bosh-gen would mistakenly upload a REALLY old
Warden Stemcell (like v64...) because of its insistence on using `bosh
public stemcells`.

Instead, we should just use the bosh.io URL that we set previously.