### PR TITLE
Omit packages with busybox from PATH and LD_LIBRARY_PATH

### DIFF
--- a/lib/bosh/gen/generators/job_generator/templates/jobs/%job_name%_simple/templates/helpers/ctl_setup.sh
+++ b/lib/bosh/gen/generators/job_generator/templates/jobs/%job_name%_simple/templates/helpers/ctl_setup.sh
@@ -29,20 +29,27 @@ redirect_output ${output_label}
 
 export HOME=${HOME:-/home/vcap}
 
-# Add all packages' /bin & /sbin into $PATH
-# (except for busybox, which is not for the host OS)
-for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin | grep -v busybox)
-do
-  export PATH=${package_bin_dir}:$PATH
-done
-
-# Add all packages' /lib into $LD_LIBRARY_PATH
-# so that dynamically-linked executables still work
-# (except for busybox, which is not for the host OS)
+# Setup the PATH and LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
-for package_lib_dir in $(ls -d /var/vcap/packages/*/lib | grep -v busybox)
+for package_dir in $(ls -d /var/vcap/packages/*)
 do
-  export LD_LIBRARY_PATH=${package_lib_dir}:$LD_LIBRARY_PATH
+  has_busybox=0
+  # Add all packages' /bin & /sbin into $PATH
+  for package_bin_dir in $(ls -d ${package_dir}/*bin)
+  do
+    # Do not add any packages that use busybox, as impacts builtin commands and
+    # is often used for different architecture (via containers)
+    if [ -f ${package_bin_dir}/busybox ]
+    then
+      has_busybox=1
+    else
+      export PATH=${package_bin_dir}:$PATH
+    fi
+  done
+  if [ "$has_busybox" == "0" ] && [ -d ${package_dir}/lib ]
+  then
+    export LD_LIBRARY_PATH=${package_dir}/lib:$LD_LIBRARY_PATH
+  fi
 done
 
 # Setup log, run and tmp folders

--- a/lib/bosh/gen/generators/package_docker_image_generator/templates/jobs/%job_name%/templates/helpers/ctl_setup.sh
+++ b/lib/bosh/gen/generators/package_docker_image_generator/templates/jobs/%job_name%/templates/helpers/ctl_setup.sh
@@ -24,10 +24,27 @@ redirect_output ${output_label}
 
 export HOME=${HOME:-/home/vcap}
 
-# Add all packages' /bin & /sbin into $PATH
-for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+# Setup the PATH and LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_dir in $(ls -d /var/vcap/packages/*)
 do
-  export PATH=${package_bin_dir}:$PATH
+  has_busybox=0
+  # Add all packages' /bin & /sbin into $PATH
+  for package_bin_dir in $(ls -d ${package_dir}/*bin)
+  do
+    # Do not add any packages that use busybox, as impacts builtin commands and
+    # is often used for different architecture (via containers)
+    if [ -f ${package_bin_dir}/busybox ]
+    then
+      has_busybox=1
+    else
+      export PATH=${package_bin_dir}:$PATH
+    fi
+  done
+  if [ "$has_busybox" == "0" ] && [ -d ${package_dir}/lib ]
+  then
+    export LD_LIBRARY_PATH=${package_dir}/lib:$LD_LIBRARY_PATH
+  fi
 done
 
 # Setup log, run and tmp folders


### PR DESCRIPTION
busybox contains binaries that duplicate the normal system binaries such as mkdir and ls, and are often built against different incompatible libraries for use in containers, which causes the jobs to fail.  This PR detects if there is a busybox executable in the packages bin dir, and if so, omits the package from the PATH and LD_LIBRARY_PATH.