### PR TITLE
Fix for multiple word deployment names and warden sanity check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 script: bundle exec rake spec
 rvm:
   - ruby-2.1.6
-  - ruby-2.2.2
+  - ruby-2.2.3
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 script: bundle exec rake spec
 rvm:
-  - ruby-2.1.9
   - ruby-2.2.5
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ script: bundle exec rake spec
 rvm:
   - ruby-2.1.9
   - ruby-2.2.5
-:wq
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 script: bundle exec rake spec
 rvm:
-  - ruby-2.1.6
-  - ruby-2.2.3
+  - ruby-2.1.9
+  - ruby-2.2.5
+:wq
 notifications:
   email:
     recipients:

--- a/lib/bosh/gen/generators/new_release_generator/templates/templates/make_manifest.tt
+++ b/lib/bosh/gen/generators/new_release_generator/templates/templates/make_manifest.tt
@@ -31,10 +31,10 @@ shift
 BOSH_STATUS=$(bosh status)
 DIRECTOR_UUID=$(echo "$BOSH_STATUS" | grep UUID | awk '{print $2}')
 DIRECTOR_CPI=$(echo "$BOSH_STATUS" | grep CPI | awk '{print $2}' | sed -e 's/_cpi//')
-DIRECTOR_NAME=$(echo "$BOSH_STATUS" | grep Name | awk '{print $2}')
+DIRECTOR_NAME=$(echo "$BOSH_STATUS" | grep Name | sed 's/.*Name *//')
 NAME=$template_prefix-$infrastructure
 
-if [[ $DIRECTOR_NAME = "warden" && ${infrastructure} != "warden" ]]; then
+if [[ $DIRECTOR_CPI = "warden" && ${infrastructure} != "warden" ]]; then
   fail "Not targeting bosh-lite with warden CPI. Please make sure you have run 'bosh target' and are targeting a BOSH lite before running this script."
   exit 1
 fi


### PR DESCRIPTION
 - Minor fix for DIRECTOR_NAME if there are multiple words with whitespace in the director name, for instance "Bosh Lite Director"
 - Modified sanity check for warden to make sure the CPI matches the infrastructure
